### PR TITLE
Fix Ledger signing to use raw transaction data

### DIFF
--- a/src/utils/LedgerSigner.ts
+++ b/src/utils/LedgerSigner.ts
@@ -64,11 +64,11 @@ export class LedgerSigner extends Signer {
     // 1. Encode transaction to bytes
     const message = encodeTransaction(transaction)
 
-    // 2. Hash the encoded transaction
-    const hash = new Uint8Array(sha256(message))
+    // 2. Sign the encoded transaction with Ledger (not hashed)
+    const signatureData = await this.ledgerManager.sign(message, this.path)
 
-    // 3. Sign the hash with Ledger
-    const signatureData = await this.ledgerManager.sign(hash, this.path)
+    // 3. Hash the encoded transaction for return value
+    const hash = new Uint8Array(sha256(message))
 
     // 4. Create signature object
     const signature = new Signature({


### PR DESCRIPTION
## Summary
- Fixes Ledger UNKNOWN_ERROR (0xb005) and (0x5515) by sending raw transaction data instead of hashed data
- NEAR Ledger app expects raw encoded transaction data, not pre-hashed data
- Removes unnecessary error handling and console logging

## Root Cause
The original implementation was sending SHA-256 hashed transaction data to the Ledger device, but the NEAR Ledger app expects the raw encoded transaction data and handles hashing internally.

## Changes Made
- Changed signing order: encode transaction → sign with Ledger → hash for return value
- Removed custom error handling that was masking the actual Ledger errors
- Removed debug logging

🤖 Generated with [Claude Code](https://claude.ai/code)